### PR TITLE
chore: change registration name to unleash-nextjs-sdk

### DIFF
--- a/lib/src/getDefinitions.test.ts
+++ b/lib/src/getDefinitions.test.ts
@@ -36,7 +36,7 @@ describe("getDefinitions", () => {
           "content-type": "application/json",
           "user-agent": "nextjs",
           "unleash-client-spec": expect.stringMatching(/\d+\.\d+\.\d+.*/),
-          "unleash-sdk": expect.stringContaining("unleash-client-nextjs:"),
+          "unleash-sdk": expect.stringContaining("unleash-nextjs-sdk:"),
           "unleash-appname": "nextjs",
         },
       }

--- a/lib/src/getDefinitions.ts
+++ b/lib/src/getDefinitions.ts
@@ -76,7 +76,7 @@ export const getDefinitions = async (
     "content-type": "application/json",
     "user-agent": appName,
     "unleash-client-spec": supportedSpecVersion,
-    "unleash-sdk": `unleash-client-nextjs:${version}`,
+    "unleash-sdk": `unleash-nextjs-sdk:${version}`,
     "unleash-appname": appName,
   };
 


### PR DESCRIPTION
I think in some situations this will still report as unleash-js-sdk when using the js client and unleash-nextjs-sdk when not. But it's fine, we're not breaking the current way of working of it